### PR TITLE
Hospital recognizer

### DIFF
--- a/src/Recognizer.py
+++ b/src/Recognizer.py
@@ -95,9 +95,12 @@ class MedicaidAccountRecognizer(PatternRecognizer):
 
     def find(self, text, entities=None):
         return find_matches(self.patterns, text, self.supported_entity)
+        
 class HospitalRecognizer(PatternRecognizer):
     def __init__(self):
-        patterns = [Pattern("HOSPITAL", r"\b",score=1.0)]
+        phrase1 = "Hospital name:"
+        phrase2 = "Hospital Name:"
+        patterns = [Pattern("HOSPITAL", rf"(?<={re.escape(phrase1)}\s)([^\n]+)|(?<={re.escape(phrase2)}\s)([^\n]+)",score=1.0)]
         super().__init__(supported_entity="HOSPITAL", patterns=patterns)
     
     def find(self, text, entities=None):

--- a/src/Recognizer.py
+++ b/src/Recognizer.py
@@ -86,3 +86,11 @@ class SSNRecognizer(PatternRecognizer):
     def find(self, text, entities=None):
         return find_matches(self.patterns, text, self.supported_entity)
 
+class HospitalRecognizer(PatternRecognizer):
+    def __init__(self):
+        patterns = [Pattern("HOSPITAL", r"\b",score=1.0)]
+        super().__init__(supported_entity="HOSPITAL", patterns=patterns)
+    
+    def find(self, text, entities=None):
+        return find_matches(self.patterns, text, self.supported_entity)
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 import os
-from Recognizer import AddressRecognizer, DOBRecognizer, TitleRecognizer, PostNominalRecognizer, SSNRecognizer, MedicaidAccountRecognizer
+from Recognizer import AddressRecognizer, DOBRecognizer, TitleRecognizer, PostNominalRecognizer, SSNRecognizer, MedicaidAccountRecognizer, HospitalRecognizer
 from presidio_analyzer import AnalyzerEngine
 from presidio_anonymizer import AnonymizerEngine
 from presidio_anonymizer.entities import OperatorConfig
@@ -17,6 +17,7 @@ title_rec = TitleRecognizer()
 postnominal_rec = PostNominalRecognizer()
 ssn_rec = SSNRecognizer()
 medicaid_rec = MedicaidAccountRecognizer()
+hospital_rec = HospitalRecognizer()  
 
 
 analyzer.registry.add_recognizer(address_rec)
@@ -25,6 +26,7 @@ analyzer.registry.add_recognizer(title_rec)
 analyzer.registry.add_recognizer(postnominal_rec)
 analyzer.registry.add_recognizer(ssn_rec)
 analyzer.registry.add_recognizer(medicaid_rec)
+analyzer.registry.add_recognizer(hospital_rec)
 
 #"./resources/ehr JMS.txt"
 
@@ -33,7 +35,7 @@ for file_path in file_path:
         content = file.read()
 
     results = analyzer.analyze(text=content,
-                            entities=["PERSON", "ADDRESS", "DOB", "SSN", "PHONE_NUMBER", "EMAIL_ADDRESS", "TITLE", "POSTNOMINAL", "MEDICAID_ACCOUNT"],
+                            entities=["PERSON", "ADDRESS", "DOB", "SSN", "PHONE_NUMBER", "EMAIL_ADDRESS", "TITLE", "POSTNOMINAL", "MEDICAID_ACCOUNT", "HOSPITAL"],
                             language='en')
 
     result = anonymizer.anonymize(
@@ -48,6 +50,7 @@ for file_path in file_path:
                 "POSTNOMINAL": OperatorConfig("replace", {"new_value": "*pn*"}), 
                 "EMAIL_ADDRESS": OperatorConfig("replace", {"new_value": "*email*"}),
                 "MEDICAID_ACCOUNT": OperatorConfig("replace", {"new_value": "*medicaid*"}),
+                "HOSPITAL": OperatorConfig("replace", {"new_value": "*hospital*"})
                 }
 
     )


### PR DESCRIPTION
The way the hospital recognizer currently works is that it looks for either "Hospital name:" or "Hospital Name:" and then finds the text after that up to the newline. Given the large variety of hospital names, I was unsure how to approach this and so I asked the professor. His response was: "Let us focus on the word "name" or "Name" at this level", which I interpreted to be how I have implemented the recognizer now. I did ask for clarification but have not received a response. If I hear anything else from the professor that would cause me to modify the hospital recognizer, I will. Also, the postnominal recognizer sometimes mistakes "Ms." for "MS" but that issue is being fixed on the Allergies and lab results branch.